### PR TITLE
Add map click event for creating locations

### DIFF
--- a/scripts/modules/locations/components/map/interactive-map.js
+++ b/scripts/modules/locations/components/map/interactive-map.js
@@ -36,6 +36,8 @@ export class InteractiveMap {
         this.mapImagePath = options.mapImagePath || './images/WorldMap.png';
         this.onLocationClick = typeof options.onLocationClick === 'function' ? options.onLocationClick : null;
         this.onMapClick = typeof options.onMapClick === 'function' ? options.onMapClick : null;
+        this.onAddLocation = typeof options.onAddLocation === 'function' ? options.onAddLocation : null;
+        this.lastClickCoordinates = null;
         this._pendingCenter = null;
 
         // Initialize locations array
@@ -578,8 +580,32 @@ export class InteractiveMap {
      * @private
      */
     _handleMapClick(e) {
-        if (this.onMapClick) {
-            this.onMapClick(e);
+        if (!this.mapContainer || !this.mapImage) return;
+
+        const rect = this.mapContainer.getBoundingClientRect();
+        const x = (e.clientX - rect.left - this.offsetX) / this.scale;
+        const y = (e.clientY - rect.top - this.offsetY) / this.scale;
+
+        const location = this._getLocationAt(x, y);
+        if (location) {
+            if (this.onLocationClick) {
+                this.onLocationClick(location.id);
+            }
+            return;
+        }
+
+        if (this.mapImage.naturalWidth && this.mapImage.naturalHeight) {
+            const coords = {
+                x: (x / this.mapImage.naturalWidth) * 100,
+                y: (y / this.mapImage.naturalHeight) * 100
+            };
+            this.lastClickCoordinates = coords;
+            if (this.onAddLocation) {
+                this.onAddLocation(coords);
+            }
+            if (this.onMapClick) {
+                this.onMapClick(coords);
+            }
         }
     }
 

--- a/scripts/modules/locations/location-manager.js
+++ b/scripts/modules/locations/location-manager.js
@@ -152,7 +152,10 @@ export class LocationManager {
         // Create the UI if it doesn't exist yet
         if (!this.locationUI) {
             console.log('Creating LocationUI');
-            this.locationUI = new LocationUI(this.locationService, this.dataManager);
+            this.locationUI = new LocationUI({
+                containerId: 'locationUIContainer',
+                locationService: this.locationService
+            });
             
             // Initialize the UI after a short delay to ensure DOM is ready
             console.log('Initializing LocationUI');


### PR DESCRIPTION
## Summary
- allow map to emit `onAddLocation` with clicked coordinates
- use LocationService in LocationUI and prefill new locations when the map is clicked
- pass LocationService into LocationUI from LocationManager

## Testing
- `npm test` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bfba3d4c8326a61faf00ddd53154