### PR TITLE
Fix guild manager initialization crash

### DIFF
--- a/scripts/modules/guild/guild-manager.js
+++ b/scripts/modules/guild/guild-manager.js
@@ -86,8 +86,12 @@ export class GuildManager {
                 ];
             }
             
-            // Save the updated state
-            this.dataManager.saveState();
+            // Persist the updated state
+            if (this.dataManager.saveData) {
+                this.dataManager.saveData();
+            } else if (this.dataManager.appState?._saveState) {
+                this.dataManager.appState._saveState();
+            }
         }
     }
     

--- a/scripts/modules/guild/ui/guild-ui.js
+++ b/scripts/modules/guild/ui/guild-ui.js
@@ -22,8 +22,14 @@ export async function initializeGuildSection() {
             </div>
         `;
         
-        // Import the data manager and guild manager
-        const { dataManager } = await import('../../../core/state/app-state.js');
+        // Import application state and create a simple data manager. The
+        // previous code attempted to import a non-existent `dataManager`
+        // export which resulted in the guild manager receiving `undefined`.
+        const { appState } = await import('../../../core/state/app-state.js');
+        const dataManager = {
+            appState,
+            saveData: () => appState.update({}, true)
+        };
         const { GuildManager } = await import('../guild-manager.js');
         
         // Initialize the guild manager if it doesn't exist


### PR DESCRIPTION
## Summary
- build dataManager in guild module from `appState`
- persist guild state using `saveData`

## Testing
- `npm test` *(fails: Module `<rootDir>/tests/test-setup.js` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846cf9a045083269d4bac420d7a4f73