### PR TITLE
Fix quests section initialization

### DIFF
--- a/scripts/modules/quests/quests-manager.js
+++ b/scripts/modules/quests/quests-manager.js
@@ -19,8 +19,7 @@ export class QuestsManager {
             dataManager.appState.quests = [];
         }
 
-        // Create the UI with the service and data manager
-        this.questUI = new QuestUI(this.questService, dataManager);
+
 
         // Initialize the UI when the DOM is ready
         if (document.readyState === 'loading') {
@@ -44,8 +43,12 @@ export class QuestsManager {
             console.log('Found existing quests in appState:', this.dataManager.appState.quests);
         }
         
-        // Create the UI with the service and data manager
-        this.questUI = new QuestUI(this.questService, this.dataManager);
+        // Create the UI with the quest service and expose it globally
+        this.questUI = new QuestUI(this.questService);
+        if (typeof window !== 'undefined') {
+            window.app = window.app || {};
+            window.app.questsUI = this.questUI;
+        }
         
         // Get all quests from the service
         let quests = this.questService.getAllQuests();

--- a/scripts/modules/quests/ui/quest-ui-main.js
+++ b/scripts/modules/quests/ui/quest-ui-main.js
@@ -4,10 +4,22 @@ import { detailsView } from './quest-details-view.js';
 import { formHandler } from './quest-form-handler.js';
 
 export class QuestUI extends BaseUI {
-    constructor(questService, options = {}) {
-        super();
+    constructor(questService) {
+        super({
+            containerId: 'quests',
+            listId: 'questList',
+            detailsId: 'questDetails',
+            searchId: 'questSearch',
+            addButtonId: 'addQuestBtn',
+            entityName: 'quest',
+            getAll: () => questService.getAllQuests(),
+            getById: (id) => questService.getQuestById(id),
+            add: (quest) => questService.createQuest(quest),
+            update: (id, updates) => questService.updateQuest(id, updates),
+            delete: (id) => questService.deleteQuest(id)
+        });
+
         this.questService = questService;
-        this.options = options;
         this.currentQuest = null;
         this.isEditing = false;
         this.initialize();


### PR DESCRIPTION
## Summary
- wire up QuestUI to BaseUI with proper options
- instantiate QuestUI after DOM is ready and register globally

## Testing
- `npm test --silent` *(fails: Module <rootDir>/tests/test-setup.js in the setupFilesAfterEnv option was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d262d8c083269bb8b74c8a79c85e