### PR TITLE
Add foundational unit tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -10,7 +10,8 @@ export default {
         'node_modules/(?!(bootstrap)/)'
     ],
     moduleNameMapper: {
-        '^@/(.*)$': '<rootDir>/$1'
+        '^@/(.*)$': '<rootDir>/$1',
+        '^https://cdn\\.jsdelivr\\.net/npm/uuid@8\\.3\\.2/dist/esm-browser/index\\.js$': '<rootDir>/tests/mocks/uuid.js'
     },
     verbose: true,
     testTimeout: 10000

--- a/tests/mocks/uuid.js
+++ b/tests/mocks/uuid.js
@@ -1,0 +1,2 @@
+export const v4 = () => 'mock-uuid';
+export default { v4 };

--- a/tests/modules/quest-utils.test.js
+++ b/tests/modules/quest-utils.test.js
@@ -1,0 +1,15 @@
+import { formatEnumValue, getStatusBadgeClass, getQuestTypeBadgeClass } from '@/scripts/modules/quests/ui/quest-utils.js';
+
+describe('quest ui utils', () => {
+  test('formatEnumValue converts value', () => {
+    expect(formatEnumValue('NOT_STARTED')).toBe('Not Started');
+  });
+
+  test('getStatusBadgeClass returns class', () => {
+    expect(getStatusBadgeClass('COMPLETED')).toBe('bg-success');
+  });
+
+  test('getQuestTypeBadgeClass defaults for unknown', () => {
+    expect(getQuestTypeBadgeClass('UNKNOWN')).toBe('bg-secondary');
+  });
+});

--- a/tests/services/data-service.test.js
+++ b/tests/services/data-service.test.js
@@ -1,0 +1,40 @@
+import { DataService, INITIAL_STATE } from '@/scripts/modules/data/index.js';
+
+describe('DataService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('initializes with the default state', () => {
+    const ds = new DataService();
+    expect(ds.appState).toEqual(INITIAL_STATE);
+  });
+
+  test('add, get, update and delete entity', () => {
+    const ds = new DataService();
+    ds.clearData();
+    const added = ds.add('quests', { title: 'Test Quest', description: 'desc', type: 'main', status: 'ongoing' });
+    const fetched = ds.get('quests', added.id);
+    expect(fetched.title).toBe('Test Quest');
+
+    const updated = ds.update('quests', added.id, { title: 'Updated Title' });
+    expect(updated.title).toBe('Updated Title');
+
+    const deleted = ds.delete('quests', added.id);
+    expect(deleted).toBe(true);
+    expect(ds.get('quests', added.id)).toBeNull();
+  });
+
+  test('export and import data', () => {
+    const ds = new DataService();
+    ds.clearData();
+    const q = ds.add('quests', { title: 'Exported Quest', description: '', type: 'main', status: 'ongoing' });
+    const exported = ds.exportData();
+
+    localStorage.clear();
+    const ds2 = new DataService();
+    ds2.importData(exported);
+    const imported = ds2.get('quests', q.id);
+    expect(imported.title).toBe('Exported Quest');
+  });
+});

--- a/tests/test-setup.js
+++ b/tests/test-setup.js
@@ -1,0 +1,3 @@
+beforeEach(() => {
+  localStorage.clear();
+});

--- a/tests/utils/date-utils.test.js
+++ b/tests/utils/date-utils.test.js
@@ -1,0 +1,8 @@
+import { formatDate } from '@/scripts/utils/date-utils.js';
+
+describe('date utils', () => {
+  test('formatDate returns formatted string', () => {
+    const date = new Date('2023-01-02T00:00:00Z');
+    expect(formatDate(date)).toBe('Jan 2, 2023');
+  });
+});

--- a/tests/utils/style-utils.test.js
+++ b/tests/utils/style-utils.test.js
@@ -1,0 +1,21 @@
+import { getRarityBadgeClass, getRarityColor, formatEnumValue, formatCurrency } from '@/scripts/utils/style-utils.js';
+
+describe('style utils', () => {
+  test('getRarityBadgeClass normalizes rarity', () => {
+    expect(getRarityBadgeClass('Very Rare')).toBe('rarity-very-rare');
+  });
+
+  test('getRarityColor falls back on unknown rarity', () => {
+    expect(getRarityColor('unknown')).toBe('#aaaaaa');
+  });
+
+  test('formatEnumValue converts snake case', () => {
+    expect(formatEnumValue('VERY_RARE')).toBe('Very Rare');
+  });
+
+  test('formatCurrency converts to proper unit', () => {
+    expect(formatCurrency(2)).toBe('2 gp');
+    expect(formatCurrency(0.5)).toBe('5 sp');
+    expect(formatCurrency(0.02)).toBe('2 cp');
+  });
+});

--- a/tests/validators/state-validator.test.js
+++ b/tests/validators/state-validator.test.js
@@ -1,0 +1,14 @@
+import { StateValidator, INITIAL_STATE } from '@/scripts/modules/data/index.js';
+
+describe('StateValidator', () => {
+  test('validates initial state with no errors', () => {
+    const errors = StateValidator.validateState(INITIAL_STATE);
+    expect(errors).toEqual([]);
+  });
+
+  test('detects missing required fields', () => {
+    const invalidState = { quests: [{ id: '1' }] };
+    const errors = StateValidator.validateState(invalidState);
+    expect(errors.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add basic Jest setup and mock for uuid
- map uuid CDN module to local mock
- create tests for style utilities, quest UI utilities, date utilities
- add comprehensive tests for DataService CRUD operations
- validate application state with StateValidator tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846d68b2ad083269779d5fd9e0f397c