### PR TITLE
Add unit tests for notes and guild modules

### DIFF
--- a/tests/modules/note-model.test.js
+++ b/tests/modules/note-model.test.js
@@ -1,0 +1,37 @@
+import { Note } from '@/scripts/modules/notes/models/note-model.js';
+import { NoteCategory } from '@/scripts/modules/notes/enums/note-enums.js';
+
+describe('Note model', () => {
+  test('initializes with defaults', () => {
+    const note = new Note('Title', 'Content');
+    expect(note.title).toBe('Title');
+    expect(note.category).toBe('lore');
+    expect(note.relatedEntities.quests).toEqual([]);
+  });
+
+  test('add and remove tags', () => {
+    const note = new Note('a','b');
+    note.addTag('important');
+    note.addTag('important');
+    expect(note.tags).toEqual(['important']);
+    note.removeTag('important');
+    expect(note.tags).toEqual([]);
+  });
+
+  test('related quest operations', () => {
+    const note = new Note('x','y');
+    expect(note.addRelatedQuest('q1')).toBe(true);
+    expect(note.addRelatedQuest('q1')).toBe(false);
+    expect(note.relatedEntities.quests).toEqual(['q1']);
+    expect(note.removeRelatedQuest('q1')).toBe(true);
+    expect(note.relatedEntities.quests).toEqual([]);
+  });
+
+  test('updateCategory validates enum', () => {
+    const note = new Note('t','c');
+    expect(note.updateCategory(NoteCategory.SESSION)).toBe(true);
+    expect(note.category).toBe(NoteCategory.SESSION);
+    expect(note.updateCategory('invalid')).toBe(false);
+    expect(note.category).toBe(NoteCategory.SESSION);
+  });
+});

--- a/tests/services/guild-service.test.js
+++ b/tests/services/guild-service.test.js
@@ -1,0 +1,33 @@
+import { GuildService } from '@/scripts/modules/guild/services/guild-service.js';
+import { DataService } from '@/scripts/modules/data/index.js';
+
+let ds;
+let service;
+
+describe('GuildService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    ds = new DataService();
+    ds.clearData();
+    ds.saveData = () => {};
+    service = new GuildService(ds);
+  });
+
+  test('create, update and delete activity', () => {
+    const act = service.createActivity({ name: 'Quest', description: '', type: 'quest' });
+    expect(service.getAllActivities().length).toBe(1);
+    const updated = service.updateActivity(act.id, { status: 'completed' });
+    expect(updated.status).toBe('completed');
+    service.deleteActivity(act.id);
+    expect(service.getAllActivities().length).toBe(0);
+  });
+
+  test('create, update and delete resource', () => {
+    const res = service.createResource({ name: 'Gold', description: '', type: 'gold', quantity: 5 });
+    expect(service.getAllResources().length).toBe(1);
+    const updated = service.updateResource(res.id, { quantity: 10 });
+    expect(updated.quantity).toBe(10);
+    service.deleteResource(res.id);
+    expect(service.getAllResources().length).toBe(0);
+  });
+});

--- a/tests/services/notes-service.test.js
+++ b/tests/services/notes-service.test.js
@@ -1,0 +1,45 @@
+import { NotesService } from '@/scripts/modules/notes/services/notes-service.js';
+import { DataService } from '@/scripts/modules/data/index.js';
+import { NoteCategory } from '@/scripts/modules/notes/enums/note-enums.js';
+
+let ds;
+let service;
+
+describe('NotesService', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    ds = new DataService();
+    ds.clearData();
+    ds.saveData = () => {};
+    service = new NotesService(ds);
+  });
+
+  test('create, update and delete note', () => {
+    const note = service.createNote('Test','Content', NoteCategory.LORE);
+    expect(ds.appState.notes.length).toBe(1);
+    const updated = service.updateNote(note.id, { title: 'Updated' });
+    expect(updated.title).toBe('Updated');
+    const deleted = service.deleteNote(note.id);
+    expect(deleted).toBe(true);
+    expect(ds.appState.notes.length).toBe(0);
+  });
+
+  test('search notes by title', () => {
+    service.createNote('Alpha','', NoteCategory.LORE);
+    service.createNote('Bravo','', NoteCategory.LORE);
+    const results = service.searchNotes('brav');
+    expect(results.map(n => n.title)).toEqual(['Bravo']);
+  });
+
+  test('tag and related entity management', () => {
+    const note = service.createNote('T','C');
+    service.addTagToNote(note.id, 'important');
+    expect(service.getNoteById(note.id).tags).toContain('important');
+    service.removeTagFromNote(note.id, 'important');
+    expect(service.getNoteById(note.id).tags).not.toContain('important');
+    service.addRelatedEntity(note.id, 'quest', 'q1');
+    expect(service.getNoteById(note.id).relatedEntities.quests).toContain('q1');
+    service.removeRelatedEntity(note.id, 'quest', 'q1');
+    expect(service.getNoteById(note.id).relatedEntities.quests).not.toContain('q1');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `Note` model behaviors
- add tests for `NotesService` covering CRUD, search, tags, and related entities
- add tests for `GuildService` covering activity and resource management

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6846e7efcd5c83269827a1756dc520e4