### PR TITLE
Add quest editing controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,9 +76,19 @@
                             <!-- Quest Details -->
                             <div class="col-md-8">
                                 <div id="questDetails" class="card h-100">
-                                    <div class="empty-state">
-                                        <i class="fas fa-scroll fa-3x mb-3"></i>
-                                        <p class="empty-state-message">Select a quest to view details</p>
+                                    <div id="questDetailsContent">
+                                        <div class="empty-state">
+                                            <i class="fas fa-scroll fa-3x mb-3"></i>
+                                            <p class="empty-state-message">Select a quest to view details</p>
+                                        </div>
+                                    </div>
+                                    <div class="quest-actions">
+                                        <button id="editQuestBtn" class="btn btn-secondary me-2" disabled>
+                                            <i class="fas fa-edit"></i> Edit
+                                        </button>
+                                        <button id="deleteQuestBtn" class="btn btn-danger" disabled>
+                                            <i class="fas fa-trash"></i> Delete
+                                        </button>
                                     </div>
                                 </div>
                             </div>

--- a/scripts/modules/quests/ui/quest-details-view.js
+++ b/scripts/modules/quests/ui/quest-details-view.js
@@ -35,6 +35,7 @@ export const detailsView = {
 
     renderQuestDetails(quest) {
         const { details } = this.elements;
+        const contentEl = details.querySelector('#questDetailsContent') || details;
         const statusClass = `status-${quest.status.toLowerCase().replace(/\s+/g, '-')}`;
         const typeClass = `type-${quest.type.toLowerCase()}`;
 
@@ -47,7 +48,7 @@ export const detailsView = {
         };
 
         const resolution = quest.resolution || {};
-        details.innerHTML = `
+        contentEl.innerHTML = `
             <div class="quest-details">
                 <div class="quest-header">
                     <h2>${escapeHtml(quest.name)}</h2>

--- a/scripts/modules/quests/ui/quest-form-handler.js
+++ b/scripts/modules/quests/ui/quest-form-handler.js
@@ -8,6 +8,7 @@ export const formHandler = {
         this.isEditing = !!quest;
         this.currentQuest = quest || null;
         const { details } = this.elements;
+        const contentEl = details.querySelector('#questDetailsContent') || details;
 
         const formHtml = `
             <form id="questForm" class="quest-form">
@@ -81,7 +82,7 @@ export const formHandler = {
                 </div>
             </form>`;
 
-        details.innerHTML = formHtml;
+        contentEl.innerHTML = formHtml;
 
         const form = document.getElementById('questForm');
         form.addEventListener('submit', (e) => this.handleFormSubmit(e));
@@ -100,7 +101,8 @@ export const formHandler = {
             if (this.currentQuest) {
                 this.showQuestDetails(this.currentQuest.id);
             } else {
-                this.elements.details.innerHTML = '';
+                const c = this.elements.details.querySelector('#questDetailsContent') || this.elements.details;
+                c.innerHTML = '';
             }
         });
     },
@@ -139,7 +141,8 @@ export const formHandler = {
             if (this.isEditing && this.currentQuest) {
                 this.showQuestDetails(this.currentQuest.id);
             } else {
-                this.elements.details.innerHTML = '';
+                const c = this.elements.details.querySelector('#questDetailsContent') || this.elements.details;
+                c.innerHTML = '';
             }
         } catch (error) {
             console.error('Error saving quest:', error);
@@ -156,7 +159,8 @@ export const formHandler = {
             showToast('Quest deleted successfully', 'success');
             if (this.currentQuest && this.currentQuest.id === questId) {
                 this.currentQuest = null;
-                this.elements.details.innerHTML = `
+                const c = this.elements.details.querySelector('#questDetailsContent') || this.elements.details;
+                c.innerHTML = `
                     <div class="text-muted text-center py-5">
                         <i class="fas fa-scroll fa-3x mb-3"></i>
                         <p>Select a quest or create a new one</p>


### PR DESCRIPTION
## Summary
- show Edit and Delete buttons on quest details
- render quest details and forms inside a dedicated `questDetailsContent` element
- keep action buttons visible when switching between forms and details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68473c1f71f08326b9d79d186f06a080