### PR TITLE
Fix absolute import paths for DataService

### DIFF
--- a/scripts/core/state/data-service-adapter.js
+++ b/scripts/core/state/data-service-adapter.js
@@ -1,4 +1,7 @@
-import { DataService } from '/scripts/modules/data/services/data-service.js';
+// Use relative path so the module works on GitHub Pages when hosted in a
+// subdirectory. Absolute paths break because the site root is not the domain
+// root when served from a project page.
+import { DataService } from '../../modules/data/services/data-service.js';
 
 /**
  * DataServiceAdapter

--- a/scripts/modules/data/ui/data-management-ui.js
+++ b/scripts/modules/data/ui/data-management-ui.js
@@ -1,4 +1,5 @@
-import { DataService } from '/scripts/modules/data/services/data-service.js';
+// Use a relative path so this module works regardless of the site's base URL.
+import { DataService } from '../services/data-service.js';
 
 /**
  * Data Management UI

--- a/scripts/modules/factions/faction-manager.js
+++ b/scripts/modules/factions/faction-manager.js
@@ -1,5 +1,7 @@
 import { Faction } from './models/faction.js';
-import { DataService } from '/scripts/modules/data/services/data-service.js';
+// Relative import to support GitHub Pages where the site may be served from a
+// subdirectory.
+import { DataService } from '../data/services/data-service.js';
 
 /**
  * Manages all faction-related operations and data

--- a/scripts/pages/data-management.js
+++ b/scripts/pages/data-management.js
@@ -1,4 +1,6 @@
-import { DataService } from '/scripts/modules/data/services/data-service.js';
+// Use a relative path so the import works correctly when the site is hosted in
+// a subdirectory (e.g. GitHub Pages project sites).
+import { DataService } from '../modules/data/services/data-service.js';
 
 export class DataManagementPage {
     constructor() {

--- a/tests/test-setup.js
+++ b/tests/test-setup.js
@@ -1,3 +1,10 @@
+// Provide a uuid implementation globally before tests run so that modules using
+// `window.uuid` during import do not fail.
+global.window = global.window || {};
+global.window.uuid = {
+  v4: () => 'mock-uuid'
+};
+
 beforeEach(() => {
   localStorage.clear();
 });


### PR DESCRIPTION
## Summary
- use relative imports for `DataService`
- initialise window.uuid for Jest tests

## Testing
- `npm test` *(fails: DataService, NotesService, GuildService, and StateValidator tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_684a99bd14648326967576ad7e618609