### PR TITLE
Fix module paths for GitHub Pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>404 Not Found</title>
+    <base href="/CampaignTracker/">
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -42,7 +43,7 @@
     <div class="container">
         <h1>404 - Page Not Found</h1>
         <p>The page you are looking for might have been removed, had its name changed, or is temporarily unavailable.</p>
-        <p><a href="/">Go to Homepage</a></p>
+        <p><a href="/CampaignTracker/">Go to Homepage</a></p>
     </div>
 </body>
 </html>

--- a/data-management.html
+++ b/data-management.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Data Management - Pathfinder World Tracker</title>
+    <base href="/CampaignTracker/">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Font Awesome -->

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Iron Meridian Campaign Tracker</title>
-    <base href="./">
+    <base href="/CampaignTracker/">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Font Awesome -->

--- a/test-character-ui.html
+++ b/test-character-ui.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Character UI Test</title>
+    <base href="/CampaignTracker/">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Font Awesome -->

--- a/test-loot-ui.html
+++ b/test-loot-ui.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Loot UI Test</title>
+    <base href="/CampaignTracker/">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Font Awesome -->


### PR DESCRIPTION
## Summary
- ensure HTML pages resolve scripts from the `CampaignTracker` subdirectory
- update the 404 page link

## Testing
- `npm test` *(fails: StateValidator, GuildService, DataService, NotesService)*

------
https://chatgpt.com/codex/tasks/task_e_684a9cb1773483269b023ff4a0195ba0