### PR TITLE
Fix NPC dropdown options missing

### DIFF
--- a/scripts/global-styles.js
+++ b/scripts/global-styles.js
@@ -170,10 +170,19 @@ function initializeRelationalInputs() {
         const placeholder = select.dataset.placeholder || `Search or select ${entityType}...`;
         const multiple = select.hasAttribute('multiple');
         
+        // Build options array from any existing <option> elements so we don't
+        // lose them when initializing TomSelect. initRelationalDropdown clears
+        // the element's innerHTML before adding the provided options, so we
+        // must supply the current options for it to re-add.
+        const options = Array.from(select.options).map(opt => ({
+            value: opt.value,
+            text: opt.textContent,
+            selected: opt.selected
+        }));
+
         // Initialize TomSelect
         try {
             // Pass the element directly instead of using it as a selector
-            const options = [];
             RelationalInputs.initRelationalDropdown(select, options, {
                 placeholder,
                 multiple,


### PR DESCRIPTION
## Summary
- keep existing options when enhancing relational dropdowns with TomSelect

## Testing
- `npm test` *(fails: StateValidator, NotesService, DataService, GuildService)*

------
https://chatgpt.com/codex/tasks/task_e_684a9fdcb87c8326b3a2eaebd1a590e3