### PR TITLE
Add conditions module

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,6 +275,33 @@
                         </div>
                     </div>
 
+                    <!-- Conditions Section -->
+                    <div id="conditions" class="section">
+                        <div class="row">
+                            <div class="col-md-4">
+                                <div class="d-flex justify-content-between align-items-center mb-3">
+                                    <h2 class="text-accent">Conditions &amp; Curses</h2>
+                                    <button id="addConditionBtn" class="btn btn-primary">
+                                        <i class="fas fa-plus"></i> Add Condition
+                                    </button>
+                                </div>
+                                <div class="input-group mb-3">
+                                    <span class="input-group-text"><i class="fas fa-search"></i></span>
+                                    <input type="text" id="conditionSearch" class="form-control" placeholder="Search conditions...">
+                                </div>
+                                <div id="conditionList" class="list-group"></div>
+                            </div>
+                            <div class="col-md-8">
+                                <div id="conditionDetails" class="card h-100">
+                                    <div class="empty-state">
+                                        <i class="fas fa-skull-crossbones fa-3x mb-3"></i>
+                                        <p class="empty-state-message">Select a condition to view details</p>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
                     <!-- Notes Section -->
                     <div id="notes" class="section">
                         <div class="row">

--- a/scripts/core/initialization/app-initializer.js
+++ b/scripts/core/initialization/app-initializer.js
@@ -113,6 +113,7 @@ export class AppInitializer {
         this._registerQuestsSection(navManager);
         this._registerCharactersSection(navManager);
         this._registerPlayersSection(navManager);
+        this._registerConditionsSection(navManager);
         this._registerFactionsSection(navManager);
 
         // Initialize other sections (locations) if needed
@@ -219,6 +220,16 @@ export class AppInitializer {
                 }
             })
             .catch(error => console.error("Failed to load players module:", error));
+    }
+
+    static _registerConditionsSection(navManager) {
+        import('../../modules/conditions/index.js')
+            .then(module => {
+                if (module.initializeConditionsSection) {
+                    navManager.registerSectionInitializer('conditions', module.initializeConditionsSection);
+                }
+            })
+            .catch(error => console.error('Failed to load conditions module:', error));
     }
 
 

--- a/scripts/modules/conditions/conditions-manager.js
+++ b/scripts/modules/conditions/conditions-manager.js
@@ -1,0 +1,15 @@
+import { ConditionService } from './services/condition-service.js';
+import { ConditionUI } from './ui/condition-ui.js';
+
+export class ConditionsManager {
+    constructor(dataManager) {
+        this.dataManager = dataManager;
+        this.service = new ConditionService(dataManager);
+        this.ui = new ConditionUI(this.service, dataManager);
+        this.ui.init();
+    }
+
+    createCondition(data) { return this.service.createCondition(data); }
+    updateCondition(id, updates) { return this.service.updateCondition(id, updates); }
+    deleteCondition(id) { return this.service.deleteCondition(id); }
+}

--- a/scripts/modules/conditions/conditions-section.js
+++ b/scripts/modules/conditions/conditions-section.js
@@ -1,0 +1,16 @@
+import { ConditionsManager } from './conditions-manager.js';
+
+export async function initializeConditionsSection() {
+    const container = document.getElementById('conditions');
+    if (!container) return;
+    if (!window.app) window.app = {};
+
+    if (!window.app.conditionsManager) {
+        const { appState } = await import('../../core/state/app-state.js');
+        const dataManager = { appState, saveData: () => appState._saveState?.() };
+        window.app.conditionsManager = new ConditionsManager(dataManager);
+    } else {
+        window.app.conditionsManager.ui.refresh();
+    }
+}
+export default initializeConditionsSection;

--- a/scripts/modules/conditions/index.js
+++ b/scripts/modules/conditions/index.js
@@ -1,0 +1,6 @@
+// Re-export all components for the conditions module
+export { Condition } from './models/condition-model.js';
+export { ConditionService } from './services/condition-service.js';
+export { ConditionUI } from './ui/condition-ui.js';
+export { ConditionsManager } from './conditions-manager.js';
+export { initializeConditionsSection } from './conditions-section.js';

--- a/scripts/modules/conditions/models/condition-model.js
+++ b/scripts/modules/conditions/models/condition-model.js
@@ -1,0 +1,16 @@
+export class Condition {
+    constructor(data = {}) {
+        this.id = data.id || `cond-${Date.now()}-${Math.floor(Math.random()*1000)}`;
+        this.name = data.name || 'Unnamed Condition';
+        this.effect = data.effect || '';
+        this.type = data.type || 'condition';
+        this.duration = data.duration || '';
+        this.isMagical = data.isMagical || false;
+        this.canStack = data.canStack || false;
+        this.notes = data.notes || '';
+        this.affectedCharacterIds = Array.isArray(data.affectedCharacterIds) ? [...data.affectedCharacterIds] : [];
+        this.relatedItemIds = Array.isArray(data.relatedItemIds) ? [...data.relatedItemIds] : [];
+        this.createdAt = data.createdAt || new Date().toISOString();
+        this.updatedAt = data.updatedAt || new Date().toISOString();
+    }
+}

--- a/scripts/modules/conditions/services/condition-service.js
+++ b/scripts/modules/conditions/services/condition-service.js
@@ -1,0 +1,56 @@
+/**
+ * Service for handling condition data operations
+ */
+export class ConditionService {
+    constructor(dataManager) {
+        this.dataManager = dataManager;
+        if (!this.dataManager.appState.conditions) {
+            this.dataManager.appState.conditions = [];
+        }
+    }
+
+    getAllConditions() {
+        return this.dataManager.appState.conditions || [];
+    }
+
+    getConditionById(id) {
+        return this.getAllConditions().find(c => c.id === id) || null;
+    }
+
+    createCondition(data) {
+        const conditions = this.getAllConditions();
+        const condition = { ...data, id: `cond-${Date.now()}-${Math.floor(Math.random()*1000)}`, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() };
+        conditions.push(condition);
+        this.dataManager.appState.conditions = conditions;
+        this.dataManager.saveData?.();
+        return condition;
+    }
+
+    updateCondition(id, updates) {
+        const conditions = this.getAllConditions();
+        const index = conditions.findIndex(c => c.id === id);
+        if (index === -1) return null;
+        const updated = { ...conditions[index], ...updates, updatedAt: new Date().toISOString() };
+        conditions[index] = updated;
+        this.dataManager.appState.conditions = conditions;
+        this.dataManager.saveData?.();
+        return updated;
+    }
+
+    deleteCondition(id) {
+        const conditions = this.getAllConditions();
+        const newList = conditions.filter(c => c.id !== id);
+        if (newList.length === conditions.length) return false;
+        this.dataManager.appState.conditions = newList;
+        this.dataManager.saveData?.();
+        return true;
+    }
+
+    searchConditions(term) {
+        const t = term.toLowerCase();
+        return this.getAllConditions().filter(c =>
+            c.name.toLowerCase().includes(t) ||
+            (c.effect && c.effect.toLowerCase().includes(t))
+        );
+    }
+}

--- a/scripts/modules/conditions/ui/condition-ui.js
+++ b/scripts/modules/conditions/ui/condition-ui.js
@@ -1,0 +1,70 @@
+import { BaseUI } from '../../../components/base-ui.js';
+import { createListItem, createDetailsPanel } from '../../../components/ui-components.js';
+
+export class ConditionUI extends BaseUI {
+    constructor(service, dataManager) {
+        super({
+            containerId: 'conditions',
+            listId: 'conditionList',
+            detailsId: 'conditionDetails',
+            searchId: 'conditionSearch',
+            addButtonId: 'addConditionBtn',
+            entityName: 'condition',
+            getAll: () => service.getAllConditions(),
+            getById: id => service.getConditionById(id),
+            add: data => service.createCondition(data),
+            update: (id, updates) => service.updateCondition(id, updates),
+            delete: id => service.deleteCondition(id)
+        });
+        this.service = service;
+        this.dataManager = dataManager;
+    }
+
+    createListItem(cond) {
+        return createListItem({
+            id: cond.id,
+            title: cond.name,
+            subtitle: cond.type,
+            isSelected: this.currentEntity && this.currentEntity.id === cond.id,
+            onClick: this.handleSelect
+        });
+    }
+
+    renderDetails(cond) {
+        if (!cond) {
+            this.detailsElement.innerHTML = `
+                <div class="empty-state">
+                    <i class="fas fa-skull-crossbones fa-3x mb-3"></i>
+                    <p class="empty-state-message">Select a condition to view details</p>
+                </div>`;
+            return;
+        }
+
+        const relatedPlayers = (cond.affectedCharacterIds || [])
+            .map(id => this._findName('players', id)).join(', ') || 'None';
+        const relatedItems = (cond.relatedItemIds || [])
+            .map(id => this._findName('loot', id)).join(', ') || 'None';
+
+        const panel = createDetailsPanel({
+            title: cond.name,
+            rows: [
+                { label: 'Type', value: cond.type },
+                { label: 'Effect', value: cond.effect },
+                { label: 'Duration', value: cond.duration || '–' },
+                { label: 'Magical', value: cond.isMagical ? 'Yes' : 'No' },
+                { label: 'Stackable', value: cond.canStack ? 'Yes' : 'No' },
+                { label: 'Notes', value: cond.notes || '' },
+                { label: 'Players', value: relatedPlayers },
+                { label: 'Items', value: relatedItems }
+            ]
+        });
+        this.detailsElement.innerHTML = '';
+        this.detailsElement.appendChild(panel);
+    }
+
+    _findName(collection, id) {
+        const list = this.dataManager.appState[collection] || [];
+        const item = list.find(e => e.id === id);
+        return item ? (item.name || item.title) : id;
+    }
+}

--- a/scripts/modules/data.js
+++ b/scripts/modules/data.js
@@ -11,6 +11,7 @@ export { Note } from './notes.js';
 export { Item, ItemType, ItemRarity } from './loot.js';
 export { Location, LocationType, DiscoveryStatus } from './locations/index.js';
 export { Player, PlayerClass } from './players/index.js';
+export { Condition } from './conditions/index.js';
 export { GuildActivity, GuildActivityType, GuildResource, GuildResourceType } from './guild/index.js';
 
 // Import the new DataService as DataManager for backward compatibility

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -27,6 +27,11 @@
                 </a>
             </li>
             <li class="nav-item">
+                <a class="nav-link text" href="#conditions">
+                    <i class="fas fa-skull-crossbones me-2"></i>Conditions
+                </a>
+            </li>
+            <li class="nav-item">
                 <a class="nav-link text" href="#locations">
                     <i class="fas fa-map-marked-alt me-2"></i>Locations
                 </a>


### PR DESCRIPTION
## Summary
- add Condition model, service, manager and UI
- hook up Conditions section in initializer
- expose conditions through data module
- add sidebar and page UI for Conditions

## Testing
- `npm test` *(fails: StateValidator, GuildService, DataService, NotesService)*

------
https://chatgpt.com/codex/tasks/task_e_684aa79007988326846d9c338fb45eda