### PR TITLE
Fix duplicate toJSON in Faction model

### DIFF
--- a/scripts/modules/factions/models/faction.js
+++ b/scripts/modules/factions/models/faction.js
@@ -10,6 +10,7 @@ export class Faction {
         this.name = data.name || 'New Faction';
         this.description = data.description || '';
         this.type = data.type || ''; // Political, Criminal, Merchant, etc.
+        this.alignment = data.alignment || 'N';
         this.attitude = data.attitude || 'Neutral'; // Attitude towards Iron Meridian
         this.influence = typeof data.influence === 'number' ? data.influence : 50; // 0-100 scale
         this.goals = data.goals || [];
@@ -60,6 +61,7 @@ export class Faction {
             name: this.name,
             description: this.description,
             type: this.type,
+            alignment: this.alignment,
             attitude: this.attitude,
             influence: this.influence,
             goals: [...this.goals],
@@ -75,26 +77,4 @@ export class Faction {
         };
     }
 
-
-    // Export to plain object for serialization
-    toJSON() {
-        return {
-            id: this.id,
-            name: this.name,
-            description: this.description,
-            type: this.type,
-            alignment: this.alignment,
-            influence: this.influence,
-            goals: [...this.goals],
-            leaders: [...this.leaders],
-            headquarters: this.headquarters,
-            relationships: { ...this.relationships },
-            assets: [...this.assets],
-            notes: this.notes,
-            tags: [...this.tags],
-            isActive: this.isActive,
-            createdAt: this.createdAt,
-            updatedAt: this.updatedAt
-        };
-    }
 }


### PR DESCRIPTION
## Summary
- remove redundant `toJSON` method from faction model
- include `alignment` field in constructor and serialization

## Testing
- `npm test` *(fails: StateValidator, GuildService, NotesService, DataService)*

------
https://chatgpt.com/codex/tasks/task_e_684aa7933c008326972dd01c80c3254d