### PR TITLE
Fix duplicate input ids and add missing search identifiers

### DIFF
--- a/index.html
+++ b/index.html
@@ -150,7 +150,7 @@
                                 </div>
                                 <div class="input-group mb-3">
                                     <span class="input-group-text"><i class="fas fa-search"></i></span>
-                                    <input type="text" id="characterSearch" class="form-control" placeholder="Search NPCs...">
+                                    <input type="text" id="npcSearch" class="form-control" placeholder="Search NPCs...">
                                 </div>
                                 <div id="characterList" class="list-group">
                                     <!-- NPCs will be loaded here -->
@@ -350,7 +350,7 @@
                             <div class="card-body">
                                 <div class="mb-3">
                                     <div class="input-group">
-                                        <input type="text" class="form-control activity-search-input" placeholder="Search activities...">
+                                        <input type="text" class="form-control activity-search-input" id="activitySearch" placeholder="Search activities...">
                                         <button class="btn btn-outline-secondary activity-search-btn" type="button">
                                             <i class="fas fa-search"></i>
                                         </button>
@@ -387,7 +387,7 @@
                             <div class="card-body">
                                 <div class="mb-3">
                                     <div class="input-group">
-                                        <input type="text" class="form-control resource-search-input" placeholder="Search resources...">
+                                        <input type="text" class="form-control resource-search-input" id="resourceSearch" placeholder="Search resources...">
                                         <button class="btn btn-outline-secondary resource-search-btn" type="button">
                                             <i class="fas fa-search"></i>
                                         </button>

--- a/templates/sections/guild.html
+++ b/templates/sections/guild.html
@@ -15,7 +15,7 @@
                             <div class="card-body">
                                 <div class="mb-3">
                                     <div class="input-group">
-                                        <input type="text" class="form-control activity-search-input" placeholder="Search activities...">
+                                        <input type="text" class="form-control activity-search-input" id="activitySearch" placeholder="Search activities...">
                                         <button class="btn btn-outline-secondary activity-search-btn" type="button">
                                             <i class="fas fa-search"></i>
                                         </button>
@@ -52,7 +52,7 @@
                             <div class="card-body">
                                 <div class="mb-3">
                                     <div class="input-group">
-                                        <input type="text" class="form-control resource-search-input" placeholder="Search resources...">
+                                        <input type="text" class="form-control resource-search-input" id="resourceSearch" placeholder="Search resources...">
                                         <button class="btn btn-outline-secondary resource-search-btn" type="button">
                                             <i class="fas fa-search"></i>
                                         </button>

--- a/templates/sections/npcs.html
+++ b/templates/sections/npcs.html
@@ -11,7 +11,7 @@
                                 </div>
                                 <div class="input-group mb-3">
                                     <span class="input-group-text"><i class="fas fa-search"></i></span>
-                                    <input type="text" id="characterSearch" class="form-control" placeholder="Search NPCs...">
+                                    <input type="text" id="npcSearch" class="form-control" placeholder="Search NPCs...">
                                 </div>
                                 <div id="characterList" class="list-group">
                                     <!-- NPCs will be loaded here -->


### PR DESCRIPTION
## Summary
- rename NPC search field ID to `npcSearch`
- add missing `id` attributes for guild search fields

## Testing
- `npm test` *(fails: StateValidator, DataService, GuildService, NotesService)*

------
https://chatgpt.com/codex/tasks/task_e_684abc0d97048326b94d892a898329ba