### PR TITLE
Fix NPC persistence

### DIFF
--- a/scripts/modules/characters/services/character-service.js
+++ b/scripts/modules/characters/services/character-service.js
@@ -125,6 +125,7 @@ export class CharacterService {
                 quests: characterData.quests || [],
                 bio: characterData.bio || '',
                 notes: characterData.notes || '',
+                status: characterData.status || 'alive',
                 createdAt: new Date().toISOString(),
                 updatedAt: new Date().toISOString()
             };


### PR DESCRIPTION
## Summary
- default new NPC `status` to `alive`

## Testing
- `npm test` *(fails: TypeError: ds.delete is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_684ac316f9cc8326a677e594276b69da