### PR TITLE
Fix NPC deletion persistence

### DIFF
--- a/scripts/modules/characters/services/character-service.js
+++ b/scripts/modules/characters/services/character-service.js
@@ -216,8 +216,16 @@ export class CharacterService {
             return removed;
         }
 
-        this.dataManager.appState = { ...this.dataManager.appState, npcs: filteredCharacters };
-        this._saveData();
+        // Fallback for environments without a full data service
+        if (this.dataManager?.appState?.update) {
+            // Use the appState's update method so persistence hooks trigger
+            this.dataManager.appState.update({ npcs: filteredCharacters }, true);
+        } else if (this.dataManager?.appState) {
+            // Directly mutate and save as a last resort
+            this.dataManager.appState.npcs = filteredCharacters;
+            this._saveData();
+        }
+
         return true;
     }
 


### PR DESCRIPTION
## Summary
- ensure local storage updates when deleting NPCs

## Testing
- `npm test` *(fails: DataService, GuildService and NotesService tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_684b092446c8832697587694168d76f5