### PR TITLE
Fix NPC persistence

### DIFF
--- a/scripts/modules/characters/services/character-service.js
+++ b/scripts/modules/characters/services/character-service.js
@@ -142,6 +142,8 @@ export class CharacterService {
             characters.push(newCharacter);
             if (this.dataManager && this.dataManager.appState && typeof this.dataManager.appState.update === 'function') {
                 this.dataManager.appState.update({ npcs: characters }, true);
+                // Explicitly persist changes to ensure new NPCs are saved
+                this._saveData();
             } else if (this.dataManager && this.dataManager.appState) {
                 this.dataManager.appState.npcs = characters;
                 this._saveData();


### PR DESCRIPTION
## Summary
- explicitly call save method when updating NPC list

## Testing
- `npm test` *(fails: ds.delete is not a function; notes-service, guild-service, state-validator tests)*

------
https://chatgpt.com/codex/tasks/task_e_684b0ba034488326bbcd5d2f2e8383a7