### PR TITLE
Add public saveData wrapper

### DIFF
--- a/scripts/core/state/data-service-adapter.js
+++ b/scripts/core/state/data-service-adapter.js
@@ -109,9 +109,9 @@ export class DataServiceAdapter {
             }
 
             // Force save if requested
-            if (saveToStorage && this.dataService._saveData) {
+            if (saveToStorage && this.dataService.saveData) {
                 console.log('Saving data to storage');
-                this.dataService._saveData();
+                this.dataService.saveData();
             }
         } catch (error) {
             console.error('Error in update:', error);

--- a/scripts/modules/data/index.js
+++ b/scripts/modules/data/index.js
@@ -4,4 +4,4 @@ export * from './validators/state-validator.js';
 export * from './services/data-service.js';
 
 // For backward compatibility
-export { DataService as DataManager } from './services/data-service.js';
+export { DataService as DataManager, saveData } from './services/data-service.js';

--- a/scripts/modules/data/services/data-service.js
+++ b/scripts/modules/data/services/data-service.js
@@ -558,7 +558,16 @@ export class DataService {
             }
         }
     }
-    
+
+    /**
+     * Public wrapper for _saveData to allow external callers
+     * to persist the current state.
+     * @returns {boolean} True if save was successful, false otherwise
+     */
+    saveData() {
+        return this._saveData();
+    }
+
     /**
      * Notify all observers of state changes
      */
@@ -1112,7 +1121,17 @@ export class DataService {
         if (!this._state[collection]) {
             throw new Error(`Invalid collection: ${collection}`);
         }
-        
+
         return this._state[collection].filter(predicate);
     }
 }
+
+// Backwards compatibility helper for modules that imported saveData directly
+// Accepts a DataService instance and delegates to its saveData method
+export function saveData(dataService) {
+    if (dataService && typeof dataService.saveData === 'function') {
+        return dataService.saveData();
+    }
+    throw new Error('DataService instance with saveData method required');
+}
+


### PR DESCRIPTION
## Summary
- expose `DataService.saveData()` wrapper that delegates to internal `_saveData`
- persist via `dataService.saveData()` in the adapter
- re-export `saveData` for compatibility

## Testing
- `npm test` *(fails: StateValidator, NotesService, DataService, GuildService tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_684b3287c14c8326ba135d91079884db