### PR TITLE
Refactor init modules to use shared appState

### DIFF
--- a/scripts/core/initialization/app-initializer.js
+++ b/scripts/core/initialization/app-initializer.js
@@ -162,7 +162,6 @@ export class AppInitializer {
 
     static async _ensureQuestManager(module) {
         if (!window.app.questsManager) {
-            const { appState } = await import('../state/app-state.js');
             const dataManager = { appState };
             window.app.questsManager = new module.QuestsManager(dataManager);
         }

--- a/scripts/modules/characters/characters-section.js
+++ b/scripts/modules/characters/characters-section.js
@@ -5,6 +5,7 @@
 
 import { CharactersManager } from './characters-manager.js';
 import { CharacterUI } from './ui/character-ui.js';
+import { appState } from '../../core/state/app-state.js';
 
 /**
  * Initialize the characters section
@@ -28,18 +29,7 @@ export async function initializeCharactersSection() {
                 // exposes a saveData function. The previous code attempted to
                 // import a non-existent `dataManager` export and resulted in the
                 // manager receiving `undefined`.
-                const { appState } = await import('../../core/state/app-state.js');
-                const dataManager = {
-                    appState,
-                    // Ensure changes are persisted immediately
-                    saveData: () => {
-                        if (typeof appState._saveState === 'function') {
-                            appState._saveState();
-                        } else {
-                            appState.update({}, true);
-                        }
-                    }
-                };
+                const dataManager = { appState };
 
                 // Initialize the characters manager
                 window.app = window.app || {};

--- a/scripts/modules/conditions/conditions-section.js
+++ b/scripts/modules/conditions/conditions-section.js
@@ -1,4 +1,5 @@
 import { ConditionsManager } from './conditions-manager.js';
+import { appState } from '../../core/state/app-state.js';
 
 export async function initializeConditionsSection() {
     const container = document.getElementById('conditions');
@@ -6,8 +7,7 @@ export async function initializeConditionsSection() {
     if (!window.app) window.app = {};
 
     if (!window.app.conditionsManager) {
-        const { appState } = await import('../../core/state/app-state.js');
-        const dataManager = { appState, saveData: () => appState._saveState?.() };
+        const dataManager = { appState };
         window.app.conditionsManager = new ConditionsManager(dataManager);
     } else {
         window.app.conditionsManager.ui.refresh();

--- a/scripts/modules/factions/factions-section.js
+++ b/scripts/modules/factions/factions-section.js
@@ -1,4 +1,5 @@
 import { FactionUI } from './ui/faction-ui.js';
+import { appState } from '../../core/state/app-state.js';
 
 /**
  * Initialize the factions section when navigated to.
@@ -13,17 +14,7 @@ export async function initializeFactionsSection() {
 
         if (!window.app) window.app = {};
         if (!window.app.factionUI) {
-            const { appState } = await import('../../core/state/app-state.js');
-            const dataManager = {
-                appState,
-                saveData: () => {
-                    if (typeof appState._saveState === 'function') {
-                        appState._saveState();
-                    } else {
-                        appState.update({}, true);
-                    }
-                }
-            };
+            const dataManager = { appState };
             window.app.factionUI = new FactionUI(container, dataManager);
         } else {
             window.app.factionUI.refresh?.();

--- a/scripts/modules/guild/ui/guild-ui.js
+++ b/scripts/modules/guild/ui/guild-ui.js
@@ -1,4 +1,5 @@
 import { GuildActivityType, GuildResourceType } from '../enums/guild-enums.js';
+import { appState } from '../../../core/state/app-state.js';
 
 // Initialize the guild section
 export async function initializeGuildSection() {
@@ -22,20 +23,8 @@ export async function initializeGuildSection() {
             </div>
         `;
         
-        // Import application state and create a simple data manager. The
-        // previous code attempted to import a non-existent `dataManager`
-        // export which resulted in the guild manager receiving `undefined`.
-        const { appState } = await import('../../../core/state/app-state.js');
-        const dataManager = {
-            appState,
-            saveData: () => {
-                if (typeof appState._saveState === 'function') {
-                    appState._saveState();
-                } else {
-                    appState.update({}, true);
-                }
-            }
-        };
+        // Create a simple data manager using the shared appState instance
+        const dataManager = { appState };
         const { GuildManager } = await import('../guild-manager.js');
         
         // Initialize the guild manager if it doesn't exist

--- a/scripts/modules/players/players-section.js
+++ b/scripts/modules/players/players-section.js
@@ -1,4 +1,5 @@
 import { PlayersManager } from './players-manager.js';
+import { appState } from '../../core/state/app-state.js';
 
 /**
  * Initialize the players section when navigated to.
@@ -13,19 +14,7 @@ export async function initializePlayersSection() {
         }
 
         if (!window.app?.playersManager) {
-            const { appState } = await import('../../core/state/app-state.js');
-            const dataManager = {
-                appState,
-                // Directly persist state using the internal save method
-                saveData: () => {
-                    if (typeof appState._saveState === 'function') {
-                        appState._saveState();
-                    } else {
-                        // Fallback for older implementations
-                        appState.update({}, true);
-                    }
-                }
-            };
+            const dataManager = { appState };
             window.app = window.app || {};
             window.app.playersManager = new PlayersManager(dataManager);
         } else {


### PR DESCRIPTION
## Summary
- import `appState` directly in section modules
- remove custom save handlers using `_saveState`
- provide shared `appState` to managers and UI
- use shared instance in `AppInitializer`

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'INITIAL_STATE' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_684b399536048326b22c655c495abb1f