### PR TITLE
Call dataService.saveData from adapter

### DIFF
--- a/scripts/core/state/data-service-adapter.js
+++ b/scripts/core/state/data-service-adapter.js
@@ -111,7 +111,11 @@ export class DataServiceAdapter {
             // Force save if requested
             if (saveToStorage) {
                 console.log('Saving data to storage');
-                this.saveData();
+                if (this.dataService && typeof this.dataService.saveData === 'function') {
+                    this.dataService.saveData();
+                } else {
+                    console.warn('dataService.saveData is not available');
+                }
             }
         } catch (error) {
             console.error('Error in update:', error);
@@ -422,7 +426,11 @@ export class DataServiceAdapter {
      * @returns {boolean} The result of saveData()
      */
     save() {
-        return this.saveData();
+        if (this.dataService && typeof this.dataService.saveData === 'function') {
+            return this.dataService.saveData();
+        }
+        console.warn('No dataService.saveData method available');
+        return false;
     }
 
     /**
@@ -431,7 +439,11 @@ export class DataServiceAdapter {
      * @returns {boolean} The result of saveData()
      */
     _saveData() {
-        return this.saveData();
+        if (this.dataService && typeof this.dataService.saveData === 'function') {
+            return this.dataService.saveData();
+        }
+        console.warn('No dataService.saveData method available');
+        return false;
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure `dataServiceAdapter.update()` saves using the underlying `dataService`
- call `dataService.saveData()` directly from the adapter's save helpers

## Testing
- `npm test` *(fails: ReferenceError: Cannot access 'INITIAL_STATE' before initialization)*

------
https://chatgpt.com/codex/tasks/task_e_684b42f695ec83269a2aa3b93bbcf20a