### PR TITLE
Add persistence tests for services

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,7 +11,15 @@ export default {
     ],
     moduleNameMapper: {
         '^@/(.*)$': '<rootDir>/$1',
-        '^https://cdn\\.jsdelivr\\.net/npm/uuid@8\\.3\\.2/dist/esm-browser/index\\.js$': '<rootDir>/tests/mocks/uuid.js'
+        '^https://cdn\\.jsdelivr\\.net/npm/uuid@8\\.3\\.2/dist/esm-browser/index\\.js$': '<rootDir>/tests/mocks/uuid.js',
+        '^@/scripts/modules/players/index.js$': '<rootDir>/tests/mocks/players-index.js',
+        '^@/scripts/modules/guild/index.js$': '<rootDir>/tests/mocks/guild-index.js',
+        '^@/scripts/modules/quests/index.js$': '<rootDir>/tests/mocks/quests-index.js',
+        '^@/scripts/modules/loot.js$': '<rootDir>/tests/mocks/loot.js',
+        '^../../players/index.js$': '<rootDir>/tests/mocks/players-index.js',
+        '^../../guild/index.js$': '<rootDir>/tests/mocks/guild-index.js',
+        '^../../quests/index.js$': '<rootDir>/tests/mocks/quests-index.js',
+        '^../../loot.js$': '<rootDir>/tests/mocks/loot.js'
     },
     verbose: true,
     testTimeout: 10000

--- a/tests/mocks/guild-index.js
+++ b/tests/mocks/guild-index.js
@@ -1,0 +1,1 @@
+export { GuildActivityType, GuildResourceType } from '../../scripts/modules/guild/enums/guild-enums.js';

--- a/tests/mocks/loot.js
+++ b/tests/mocks/loot.js
@@ -1,0 +1,1 @@
+export { ItemType, ItemRarity } from '../../scripts/modules/loot/enums/loot-enums.js';

--- a/tests/mocks/players-index.js
+++ b/tests/mocks/players-index.js
@@ -1,0 +1,1 @@
+export { PlayerClass } from '../../scripts/modules/players/enums/player-enums.js';

--- a/tests/mocks/quests-index.js
+++ b/tests/mocks/quests-index.js
@@ -1,0 +1,1 @@
+export { QuestType, QuestStatus } from '../../scripts/modules/quests/enums/quest-enums.js';

--- a/tests/services/guild-service.test.js
+++ b/tests/services/guild-service.test.js
@@ -9,7 +9,6 @@ describe('GuildService', () => {
     localStorage.clear();
     ds = new DataService();
     ds.clearData();
-    ds.saveData = () => {};
     service = new GuildService(ds);
   });
 

--- a/tests/services/notes-service.test.js
+++ b/tests/services/notes-service.test.js
@@ -10,7 +10,8 @@ describe('NotesService', () => {
     localStorage.clear();
     ds = new DataService();
     ds.clearData();
-    ds.saveData = () => {};
+    ds._state.notes = [];
+    ds.saveData();
     service = new NotesService(ds);
   });
 

--- a/tests/services/service-persistence.test.js
+++ b/tests/services/service-persistence.test.js
@@ -1,0 +1,34 @@
+import { DataService } from '@/scripts/modules/data/index.js';
+import { NotesService } from '@/scripts/modules/notes/services/notes-service.js';
+import { LocationService } from '@/scripts/modules/locations/services/location-service.js';
+
+describe('Service persistence to localStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  test('createNote saves to localStorage', () => {
+    const ds = new DataService();
+    ds.clearData();
+    ds._state.notes = [];
+    ds.saveData();
+    const notes = new NotesService(ds);
+    notes.createNote('Persisted', 'note');
+    const saved = JSON.parse(localStorage.getItem('ironMeridianState'));
+    expect(saved.notes.length).toBe(1);
+    expect(saved.notes[0].title).toBe('Persisted');
+  });
+
+  test('updateLocation saves to localStorage', () => {
+    const ds = new DataService();
+    ds.clearData();
+    ds._state.locations = [];
+    ds.saveData();
+    const locations = new LocationService(ds);
+    const loc = locations.createLocation({ name: 'Town', description: 'old' });
+    locations.updateLocation(loc.id, { description: 'new' });
+    const saved = JSON.parse(localStorage.getItem('ironMeridianState'));
+    expect(saved.locations.length).toBe(1);
+    expect(saved.locations[0].description).toBe('new');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest moduleNameMapper stubs to avoid cyclic imports in tests
- remove saveData stubbing in service tests
- ensure NotesService tests create notes collection
- add new tests verifying service persistence to localStorage

## Testing
- `npm test` *(fails: 4 failed, 5 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684b44507ebc832684022c2750f26acf