### PR TITLE
Fix NPC persistence

### DIFF
--- a/scripts/modules/characters/characters-section.js
+++ b/scripts/modules/characters/characters-section.js
@@ -29,7 +29,11 @@ export async function initializeCharactersSection() {
                 // exposes a saveData function. The previous code attempted to
                 // import a non-existent `dataManager` export and resulted in the
                 // manager receiving `undefined`.
-                const dataManager = { appState };
+                // Use the underlying DataService instance but keep a reference
+                // to appState for backwards compatibility with modules that
+                // expect `dataManager.appState`.
+                const dataManager = appState.dataService;
+                dataManager.appState = appState;
 
                 // Initialize the characters manager
                 window.app = window.app || {};


### PR DESCRIPTION
## Summary
- ensure CharactersManager uses the DataService instance

## Testing
- `npm test` *(fails: StateValidator and DataService related tests)*

------
https://chatgpt.com/codex/tasks/task_e_684bb1403e708326b83575763a356a44