### PR TITLE
Refactor modules to reuse DataService singleton

### DIFF
--- a/scripts/core/state/data-service-adapter.js
+++ b/scripts/core/state/data-service-adapter.js
@@ -5,6 +5,8 @@
  * It provides a compatible interface for the rest of the application while using
  * the new DataService under the hood.
  */
+import { DataServiceInitializer } from '../initialization/data-service-initializer.js';
+
 export class DataServiceAdapter {
     /**
      * Create a new DataServiceAdapter instance
@@ -17,10 +19,9 @@ export class DataServiceAdapter {
         if (dataService) {
             this.setDataService(dataService);
         } else {
-            // Import DataService dynamically to avoid circular dependencies
-            import('../../modules/data/services/data-service.js')
-                .then(module => {
-                    this.setDataService(new module.DataService());
+            DataServiceInitializer.initialize()
+                .then(() => {
+                    this.setDataService(DataServiceInitializer.getDataService());
                 })
                 .catch(error => {
                     console.error('Failed to initialize DataService:', error);

--- a/scripts/modules/data/ui/data-management-ui.js
+++ b/scripts/modules/data/ui/data-management-ui.js
@@ -1,5 +1,5 @@
 // Use a relative path so this module works regardless of the site's base URL.
-import { DataService } from '../services/data-service.js';
+import { DataServiceInitializer } from '../../../core/initialization/data-service-initializer.js';
 
 /**
  * Data Management UI
@@ -11,7 +11,7 @@ export class DataManagementUI {
      * @param {DataService} dataService - The data service instance
      */
     constructor(dataService = null) {
-        this.dataService = dataService || new DataService();
+        this.dataService = dataService || DataServiceInitializer.getDataService();
         this.initialize();
     }
     

--- a/scripts/modules/factions/faction-manager.js
+++ b/scripts/modules/factions/faction-manager.js
@@ -1,7 +1,7 @@
 import { Faction } from './models/faction.js';
 // Relative import to support GitHub Pages where the site may be served from a
 // subdirectory.
-import { DataService } from '../data/services/data-service.js';
+import { DataServiceInitializer } from '../../core/initialization/data-service-initializer.js';
 
 /**
  * Manages all faction-related operations and data
@@ -12,7 +12,7 @@ export class FactionManager {
      * @param {DataService} dataService - The application's data service
      */
     constructor(dataService = null) {
-        this.dataService = dataService || new DataService();
+        this.dataService = dataService || DataServiceInitializer.getDataService();
         this.factions = new Map();
         this.initialized = false;
         this.loadFactions();

--- a/scripts/modules/factions/factions-section.js
+++ b/scripts/modules/factions/factions-section.js
@@ -1,5 +1,5 @@
 import { FactionUI } from './ui/faction-ui.js';
-import { DataService } from '../data/services/data-service.js';
+import { DataServiceInitializer } from '../../core/initialization/data-service-initializer.js';
 
 /**
  * Initialize the factions section when navigated to.
@@ -14,8 +14,7 @@ export async function initializeFactionsSection() {
 
         if (!window.app) window.app = {};
         if (!window.app.factionUI) {
-            // Create a new DataService instance for the FactionUI
-            const dataService = new DataService();
+            const dataService = DataServiceInitializer.getDataService();
             window.app.factionUI = new FactionUI(container, dataService);
         } else {
             window.app.factionUI.refresh?.();

--- a/scripts/pages/data-management.js
+++ b/scripts/pages/data-management.js
@@ -1,6 +1,6 @@
 // Use a relative path so the import works correctly when the site is hosted in
 // a subdirectory (e.g. GitHub Pages project sites).
-import { DataService } from '../modules/data/services/data-service.js';
+import { DataServiceInitializer } from '../core/initialization/data-service-initializer.js';
 
 export class DataManagementPage {
     constructor() {
@@ -15,7 +15,7 @@ export class DataManagementPage {
             this.importDataBtn.classList.add('btn-secondary');
         }
         
-        this.dataService = new DataService();
+        this.dataService = DataServiceInitializer.getDataService();
         this._bindEvents();
         
         console.log('DataManagementPage initialized');


### PR DESCRIPTION
## Summary
- use `DataServiceInitializer.getDataService()` in faction sections
- share the DataService instance in the data management page and UI
- inject singleton service into faction manager
- update DataServiceAdapter to retrieve the instance via initializer

## Testing
- `npm test` *(fails: Cannot find module '../../scripts/modules/guild/enums/guild-enums.js')*

------
https://chatgpt.com/codex/tasks/task_e_6862819435688326b91c5ca6054d1553