### PR TITLE
Add mobile sidebar toggle

### DIFF
--- a/data-management.html
+++ b/data-management.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="dist/css/main.min.css">
 </head>
 <body class="app-container" data-page="data-management">
+    <div id="header-placeholder"></div>
     <div class="container-fluid">
         <div class="row">
             <!-- Sidebar -->
@@ -73,6 +74,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 
     <!-- Sidebar Loader -->
+    <script src="scripts/header-loader.js" type="module"></script>
     <script src="scripts/sidebar-loader.js" type="module"></script>
 
     <!-- Application Scripts -->

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="dist/css/main.min.css">
 </head>
 <body>
+    <div id="header-placeholder"></div>
     <div class="container-fluid">
         <div class="row">
             <!-- Sidebar Navigation -->
@@ -491,6 +492,7 @@
     </script>
     
     <!-- Sidebar Loader -->
+    <script src="scripts/header-loader.js" type="module"></script>
     <script src="scripts/sidebar-loader.js" type="module"></script>
 
     <!-- Custom JavaScript -->

--- a/scripts/header-loader.js
+++ b/scripts/header-loader.js
@@ -1,0 +1,22 @@
+export async function loadHeader() {
+    const placeholder = document.getElementById('header-placeholder');
+    if (!placeholder) return;
+    try {
+        const resp = await fetch('templates/header.html');
+        if (!resp.ok) throw new Error('Failed to load header template');
+        const html = await resp.text();
+        placeholder.outerHTML = html;
+
+        const toggleBtn = document.getElementById('sidebarToggle');
+        const sidebar = document.querySelector('.app-sidebar');
+        if (toggleBtn && sidebar) {
+            toggleBtn.addEventListener('click', () => {
+                sidebar.classList.toggle('show');
+            });
+        }
+    } catch (err) {
+        console.error(err);
+    }
+}
+
+document.addEventListener('DOMContentLoaded', loadHeader);

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,0 +1,6 @@
+<header class="app-header">
+    <button class="menu-toggle" id="sidebarToggle" aria-label="Toggle navigation">
+        <i class="fas fa-bars"></i>
+    </button>
+    <span class="header-brand text-accent">Iron Meridian</span>
+</header>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -1,4 +1,4 @@
-<nav class="col-md-3 col-lg-2 d-md-block sidebar collapse bg-dark text-light min-vh-100">
+<nav class="app-sidebar col-md-3 col-lg-2 d-md-block sidebar collapse bg-dark text-light min-vh-100">
     <div class="position-sticky pt-3">
         <ul class="nav flex-column">
             <li class="nav-item">


### PR DESCRIPTION
## Summary
- add header template with hamburger button
- load header dynamically with new loader script
- make sidebar toggleable on small screens

## Testing
- `npm run build:css`
- `npm test` *(fails: Cannot find module '../../scripts/modules/guild/enums/guild-enums.js' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6862af3be524832699f8eb8fdb760e7f