### PR TITLE
Fix mobile nav background

### DIFF
--- a/scripts/header-loader.js
+++ b/scripts/header-loader.js
@@ -14,6 +14,11 @@ export async function loadHeader() {
                 if (sidebar) {
                     sidebar.classList.toggle('show');
                 }
+
+                const headerNav = document.getElementById('mainNav');
+                if (headerNav && window.innerWidth <= 991) {
+                    headerNav.classList.toggle('show');
+                }
             });
         }
     } catch (err) {

--- a/templates/header.html
+++ b/templates/header.html
@@ -3,4 +3,16 @@
         <i class="fas fa-bars"></i>
     </button>
     <span class="header-brand text-accent">Iron Meridian</span>
+    <nav class="header-nav" id="mainNav">
+        <a class="nav-link" href="#dashboard"><i class="fas fa-tachometer-alt icon"></i>Dashboard</a>
+        <a class="nav-link" href="#quests"><i class="fas fa-scroll icon"></i>Quests</a>
+        <a class="nav-link" href="#players"><i class="fas fa-users icon"></i>Players</a>
+        <a class="nav-link" href="#characters"><i class="fas fa-user-shield icon"></i>NPCs</a>
+        <a class="nav-link" href="#loot"><i class="fas fa-coins icon"></i>Loot &amp; Curses</a>
+        <a class="nav-link" href="#locations"><i class="fas fa-map-marked-alt icon"></i>Locations</a>
+        <a class="nav-link" href="#notes"><i class="fas fa-book icon"></i>Notes</a>
+        <a class="nav-link" href="#guild-logs"><i class="fas fa-shield-alt icon"></i>Guild Logs</a>
+        <a class="nav-link" href="#factions"><i class="fas fa-flag icon"></i>Factions</a>
+        <a class="nav-link" href="data-management.html"><i class="fas fa-database icon"></i>Data Management</a>
+    </nav>
 </header>


### PR DESCRIPTION
## Summary
- add navigation links inside `header.html` so they open from the hamburger menu
- toggle header navigation visibility in `header-loader.js`

## Testing
- `npm test --silent` *(fails: Cannot find module '../../scripts/modules/guild/enums/guild-enums.js')*
- `npm run build:css --silent`

------
https://chatgpt.com/codex/tasks/task_e_6862b93f9d788326a2b41b01dbfa0864