### PR TITLE
Fix mobile nav collapse after clicking

### DIFF
--- a/scripts/header-loader.js
+++ b/scripts/header-loader.js
@@ -8,16 +8,25 @@ export async function loadHeader() {
         placeholder.outerHTML = html;
 
         const toggleBtn = document.getElementById('sidebarToggle');
+        const headerNav = document.getElementById('mainNav');
         if (toggleBtn) {
             toggleBtn.addEventListener('click', () => {
                 const isMobile = window.innerWidth <= 991;
                 const sidebar = document.querySelector('.app-sidebar');
-                const headerNav = document.getElementById('mainNav');
 
                 if (isMobile) {
                     if (headerNav) headerNav.classList.toggle('show');
                 } else {
                     if (sidebar) sidebar.classList.toggle('show');
+                }
+            });
+        }
+
+        // Collapse the mobile dropdown after navigating
+        if (headerNav) {
+            headerNav.addEventListener('click', (e) => {
+                if (e.target.closest('a') && window.innerWidth <= 991) {
+                    headerNav.classList.remove('show');
                 }
             });
         }


### PR DESCRIPTION
## Summary
- collapse mobile dropdown nav when a navigation link is clicked

## Testing
- `npm test` *(fails: Cannot find module '../../scripts/modules/guild/enums/guild-enums.js')*

------
https://chatgpt.com/codex/tasks/task_e_6862c5401174832699aa572d41976535