### PR TITLE
Fix mobile dropdown closing

### DIFF
--- a/scripts/header-loader.js
+++ b/scripts/header-loader.js
@@ -24,11 +24,20 @@ export async function loadHeader() {
 
         // Collapse the mobile dropdown after navigating
         if (headerNav) {
-            headerNav.addEventListener('click', (e) => {
-                if (e.target.closest('a') && window.innerWidth <= 991) {
+            const collapseMenu = () => {
+                if (window.innerWidth <= 991) {
                     headerNav.classList.remove('show');
                 }
+            };
+
+            headerNav.addEventListener('click', (e) => {
+                if (e.target.closest('a')) {
+                    collapseMenu();
+                }
             });
+
+            // Support closing the menu when navigation changes without a click
+            window.addEventListener('hashchange', collapseMenu);
         }
     } catch (err) {
         console.error(err);


### PR DESCRIPTION
## Summary
- collapse the mobile menu after navigation

## Testing
- `npm test` *(fails: jest tests cannot run)*

------
https://chatgpt.com/codex/tasks/task_e_6862e03cba148326805afc297bc0ba90