### PR TITLE
Improve mobile quest editing

### DIFF
--- a/scripts/modules/quests/ui/quest-form-handler.js
+++ b/scripts/modules/quests/ui/quest-form-handler.js
@@ -4,6 +4,13 @@ import { formatEnumValue } from './quest-utils.js';
 import { initEntityDropdown, getDropdownValue } from '../../../utils/relational-inputs.js';
 
 export const formHandler = {
+    toggleListVisibility(show = true) {
+        const { list, search, addButton } = this.elements;
+        const method = show ? 'remove' : 'add';
+        list?.classList[method]('d-none');
+        search?.classList[method]('d-none');
+        addButton?.classList[method]('d-none');
+    },
     showQuestForm(quest = null) {
         this.isEditing = !!quest;
         this.currentQuest = quest || null;
@@ -84,6 +91,8 @@ export const formHandler = {
 
         contentEl.innerHTML = formHtml;
 
+        this.toggleListVisibility(false);
+
         const form = document.getElementById('questForm');
         form.addEventListener('submit', (e) => this.handleFormSubmit(e));
 
@@ -98,6 +107,7 @@ export const formHandler = {
         initEntityDropdown('#relatedQuests', 'quest', quests, { multiple: true });
 
         document.getElementById('cancelQuestBtn').addEventListener('click', () => {
+            this.toggleListVisibility(true);
             if (this.currentQuest) {
                 this.showQuestDetails(this.currentQuest.id);
             } else {
@@ -146,6 +156,7 @@ export const formHandler = {
                 const c = this.elements.details.querySelector('#questDetailsContent') || this.elements.details;
                 c.innerHTML = '';
             }
+            this.toggleListVisibility(true);
         } catch (error) {
             console.error('Error saving quest:', error);
             showToast(`Failed to save quest: ${error.message}`, 'error');


### PR DESCRIPTION
## Summary
- hide the quest list/search while the quest form is visible to provide more space on small screens

## Testing
- `npm test` *(fails: Cannot find module '../../scripts/modules/guild/enums/guild-enums.js')*

------
https://chatgpt.com/codex/tasks/task_e_6862f0f19ea883268fc75f4a8f10422e