### PR TITLE
Fix missing guild enums and add DataService helpers

### DIFF
--- a/scripts/modules/data/services/data-service.js
+++ b/scripts/modules/data/services/data-service.js
@@ -893,6 +893,42 @@ export class DataService {
         this._saveData();
         return true;
     }
+
+    /**
+     * Alias for remove to maintain backwards compatibility
+     * @param {string} collection - The collection name
+     * @param {string} id - The entity ID
+     * @returns {boolean} True if removed, false otherwise
+     */
+    delete(collection, id) {
+        return this.remove(collection, id);
+    }
+
+    /**
+     * Merge updates into the current state and persist the result
+     * @param {Object} updates - Partial state updates
+     * @returns {Object} The updated state
+     */
+    updateState(updates = {}) {
+        if (!updates || typeof updates !== 'object') {
+            throw new Error('Updates must be an object');
+        }
+
+        const newState = { ...this._state };
+        for (const [key, value] of Object.entries(updates)) {
+            if (Array.isArray(value)) {
+                newState[key] = [...value];
+            } else if (value && typeof value === 'object') {
+                newState[key] = { ...(newState[key] || {}), ...value };
+            } else {
+                newState[key] = value;
+            }
+        }
+
+        this._state = newState;
+        this._saveData();
+        return this._getStateCopy();
+    }
     
     // ====================================
     // Entity-Specific Methods

--- a/scripts/modules/guild/enums/guild-enums.js
+++ b/scripts/modules/guild/enums/guild-enums.js
@@ -1,0 +1,2 @@
+export { GuildActivityType } from './guild-activity-type.js';
+export { GuildResourceType } from './guild-resource-type.js';


### PR DESCRIPTION
## Summary
- provide missing guild-enums export for tests
- add `delete` and `updateState` helpers to DataService for compatibility

## Testing
- `npm test` *(fails: GuildService and other suites still failing)*

------
https://chatgpt.com/codex/tasks/task_e_68637c51023083269b6792ef059179b4