### PR TITLE
Fix quest state filtering

### DIFF
--- a/scripts/modules/data/services/data-service.js
+++ b/scripts/modules/data/services/data-service.js
@@ -187,12 +187,11 @@ export class DataService {
             console.log('Initializing quests array');
             fixedState.quests = [];
         } else {
-            fixedState.quests = fixedState.quests.filter(quest => 
-                quest && 
-                typeof quest === 'object' && 
-                quest.id && 
-                quest.title && 
-                quest.name
+            fixedState.quests = fixedState.quests.filter(quest =>
+                quest &&
+                typeof quest === 'object' &&
+                quest.id &&
+                (quest.title || quest.name)
             ).map(quest => ({
                 ...quest,
                 // Ensure required fields exist with defaults


### PR DESCRIPTION
## Summary
- avoid dropping quests missing `title` or `name` during state repair

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68639a6f5b188326b736018f792d5f52