### PR TITLE
Improve error logging in DataService

### DIFF
--- a/scripts/modules/data/services/data-service.js
+++ b/scripts/modules/data/services/data-service.js
@@ -526,8 +526,12 @@ export class DataService {
             
             if (errors.length > 0) {
                 console.warn(`[DataService] Found ${errors.length} validation errors before saving:`);
-                errors.forEach((error, index) => {
-                    console.warn(`[${index + 1}] ${error.path}: ${error.message}`);
+                errors.forEach((err, idx) => {
+                    if (typeof err === 'string') {
+                        console.warn(`[${idx + 1}] ${err}`);
+                    } else {
+                        console.warn(`[${idx + 1}] ${err.path}: ${err.message}`);
+                    }
                 });
                 
                 // Log problematic state parts for debugging
@@ -551,8 +555,12 @@ export class DataService {
                     
                     if (fixedErrors.length > 0) {
                         console.error(`[DataService] Could not fix all validation errors (${fixedErrors.length} remaining):`);
-                        fixedErrors.forEach((error, index) => {
-                            console.error(`[${index + 1}] ${error.path}: ${error.message}`);
+                        fixedErrors.forEach((err, idx) => {
+                            if (typeof err === 'string') {
+                                console.error(`[${idx + 1}] ${err}`);
+                            } else {
+                                console.error(`[${idx + 1}] ${err.path}: ${err.message}`);
+                            }
                         });
                         
                         // Log the fixed state that still has errors for debugging


### PR DESCRIPTION
## Summary
- make error logging resilient when saving data
- output simple strings properly for validation errors

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68639f44e4648326a347ee2e39bd4d05