### PR TITLE
Adjust quests manager initialization options

### DIFF
--- a/scripts/core/initialization/app-initializer.js
+++ b/scripts/core/initialization/app-initializer.js
@@ -187,7 +187,7 @@ export class AppInitializer {
                 console.error('DataService not available in appState');
                 return;
             }
-            window.app.questsManager = new module.QuestsManager(dataService);
+            window.app.questsManager = new module.QuestsManager(dataService, { createSamples: false });
             console.log('QuestsManager initialized with DataService');
         }
     }


### PR DESCRIPTION
## Summary
- update `QuestsManager` constructor to accept `options`
- only create sample quests when `options.createSamples` is true
- disable sample quest creation in `AppInitializer`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863a446f2c883269003f67df8fd8507