### PR TITLE
Fix player creation bug

### DIFF
--- a/scripts/modules/players/services/player-service-new.js
+++ b/scripts/modules/players/services/player-service-new.js
@@ -94,13 +94,17 @@ export class PlayerService {
                 : PlayerRace.HUMAN;
             
             // Create player with required fields and defaults
+            // Note: Player constructor expects (name, class, level, id, createdAt, updatedAt)
+            // Race is not part of the constructor parameters
             const player = new Player(
                 data.name || 'Unnamed Player',
                 playerClass,
                 typeof data.level === 'number' ? data.level : 1,
-                race,
                 data.id || `player-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
             );
+
+            // Assign race separately so it persists in the saved state
+            player.race = race;
             
             // Add optional fields
             if (data.experience !== undefined) player.experience = data.experience;


### PR DESCRIPTION
## Summary
- fix parameter order when instantiating Player so ID isn't overwritten
- keep race value by assigning it explicitly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863cb62c2508326a1facb399cac6a13