### PR TITLE
Fix loot manager initialization with AppState

### DIFF
--- a/scripts/modules/loot/loot-manager.js
+++ b/scripts/modules/loot/loot-manager.js
@@ -22,12 +22,16 @@ export class LootManager {
     constructor(appState) {
         console.log('[LootManager] Initializing with appState/dataService:', appState ? 'valid' : 'invalid');
 
-        if (appState && typeof appState.saveData === 'function') {
-            // A DataService instance was provided
+        if (appState?.dataService) {
+            // If an AppState/DataServiceAdapter was provided, use its underlying DataService
+            this.dataManager = appState.dataService;
+            this.appState = this.dataManager.exportState();
+        } else if (appState && typeof appState.saveData === 'function') {
+            // A DataService instance was provided directly
             this.dataManager = appState;
             this.appState = appState.exportState ? appState.exportState() : appState.appState;
         } else {
-            // Fallback to legacy behaviour expecting an appState object
+            // Fallback to legacy behaviour expecting a plain appState object
             this.appState = appState;
             this.dataManager = appState?.dataManager || appState?.dataService || {
                 appState: appState,


### PR DESCRIPTION
## Summary
- ensure LootManager uses the underlying DataService when an AppState
  instance is supplied

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6867c5049b148326b430cb4c39e3b976