### PR TITLE
Fix loot detail rendering

### DIFF
--- a/scripts/modules/loot/ui/LootUI.js
+++ b/scripts/modules/loot/ui/LootUI.js
@@ -7,6 +7,7 @@ import { BaseUI } from '../../../components/base-ui.js';
 import { LootList } from './LootList.js';
 import { LootForm } from './LootForm.js';
 import { showToast } from '../../../components/ui-components.js';
+import { formatEnumValue, getRarityColor } from '../../../utils/style-utils.js';
 
 export class LootUI extends BaseUI {
     // Class field syntax for methods to ensure proper binding


### PR DESCRIPTION
## Summary
- fix runtime error when selecting loot items by importing missing util functions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686b99dc0a94832690a356c3e680c364