### PR TITLE
Fix LootUI formatEnumValue import

### DIFF
--- a/scripts/modules/loot/ui/LootUI.js
+++ b/scripts/modules/loot/ui/LootUI.js
@@ -7,7 +7,8 @@ import { BaseUI } from '../../../components/base-ui.js';
 import { LootList } from './LootList.js';
 import { LootForm } from './LootForm.js';
 import { showToast } from '../../../components/ui-components.js';
-import { formatEnumValue, getRarityColor } from '../../../utils/style-utils.js';
+// Use local utilities to avoid module resolution issues in the browser
+import { formatEnumValue, getRarityColor } from './utils.js';
 
 export class LootUI extends BaseUI {
     // Class field syntax for methods to ensure proper binding


### PR DESCRIPTION
## Summary
- resolve `formatEnumValue` not defined error in LootUI by importing from local utilities

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686ba8a10fc883269c6133c50ff11359