### PR TITLE
Fix missing class closing bracket

### DIFF
--- a/scripts/modules/locations/components/map/interactive-map.js
+++ b/scripts/modules/locations/components/map/interactive-map.js
@@ -279,3 +279,5 @@ export class InteractiveMap {
 
 Object.assign(InteractiveMap.prototype, renderMethods, eventMethods, utilMethods);
 
+}
+


### PR DESCRIPTION
## Summary
- close `InteractiveMap` class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686bb763dc0c8326833b185da3ae35eb