### PR TITLE
Fix map container height

### DIFF
--- a/scripts/modules/locations/components/map/interactive-map.js
+++ b/scripts/modules/locations/components/map/interactive-map.js
@@ -136,8 +136,13 @@ export class InteractiveMap {
 
             // Ensure container has dimensions
             this.container.style.width = '100%';
-            this.container.style.height = '100%';
-            this.container.style.minHeight = '500px'; // Ensure minimum height
+            if (!this.container.style.height) {
+                // Only set height if not already defined to avoid collapsing to zero
+                this.container.style.height = '100%';
+            }
+            if (!this.container.style.minHeight) {
+                this.container.style.minHeight = '500px'; // Ensure minimum height
+            }
 
             // Create map container
             this.mapContainer = document.createElement('div');


### PR DESCRIPTION
## Summary
- prevent `InteractiveMap` from overwriting map container height

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686d13cf34088326ac8433277d0ca4d2